### PR TITLE
num layer: move most common numbers to home row

### DIFF
--- a/miryoku/custom_config.h
+++ b/miryoku/custom_config.h
@@ -22,3 +22,9 @@ XXX  XXX  XXX  XXX  XXX            K33  K34  K32                 K35  K37  K36  
 U_MT(LGUI, A),     U_MT(LALT, R),     U_MT(LCTRL, S),    U_MT(LSHFT, T),    &kp G,             &kp M,             U_MT(LSHFT, N),    U_MT(LCTRL, E),    U_MT(LALT, I),     U_MT(LGUI, O),     \
 U_LT(U_BUTTON, Z), U_MT(RALT, X),     &kp C,             &kp D,             &kp V,             &kp K,             &kp H,             &kp COMMA,         U_MT(RALT, DOT),   U_LT(U_BUTTON, SLASH),\
 U_NP,              U_NP,              U_LT(U_MOUSE, ESC),U_LT(U_NAV, SPC),  U_LT(U_MEDIA, RET),U_LT(U_FUN, TAB),  U_LT(U_NUM, BSPC), U_LT(U_SYM, DEL),  U_NP,              U_NP
+
+#define MIRYOKU_LAYER_NUM \
+&kp LBKT,          &kp N7,            &kp N8,            &kp N9,            &kp RBKT,          U_NA,              &u_to_U_BASE,      &u_to_U_EXTRA,     &u_to_U_TAP,       U_BOOT,            \
+&kp SEMI,          &kp N1,            &kp N2,            &kp N3,            &kp EQUAL,         U_NA,              &kp LSHFT,         &kp LCTRL,         &kp LALT,          &kp LGUI,          \
+&kp GRAVE,         &kp N4,            &kp N5,            &kp N6,            &kp BSLH,          U_NA,              &u_to_U_NUM,       &u_to_U_NAV,       &kp RALT,          U_NA,              \
+U_NP,              U_NP,              &kp DOT,           &kp N0,            &kp MINUS,         U_NA,              U_NA,              U_NA,              U_NP,              U_NP


### PR DESCRIPTION
Based on [Benford's law](https://en.wikipedia.org/wiki/Benford%27s_law) small digits are more likely to appear in numerical data.

`1` `2` `3` was swapped with `4` `5` `6`.

closes #2 