### PR TITLE
mask ctrl from nav long left/right

### DIFF
--- a/miryoku/hold_tap.dtsi
+++ b/miryoku/hold_tap.dtsi
@@ -7,6 +7,10 @@
 #include <dt-bindings/zmk/outputs.h>
 #include <dt-bindings/zmk/rgb.h>
 
+#include "mask_mods.h"
+
+#include "mask_mods.dtsi"
+
 #define HOLD_TAP_FUNCTION(NAME, HOLD_BINDING, BINDING) \
 / { \
   behaviors { \
@@ -29,23 +33,31 @@ HOLD_TAP_FUNCTION(out_hold_tap, &out, &out)
 HOLD_TAP_FUNCTION(rgb_hold_tap, &rgb_ug, &rgb_ug)
 HOLD_TAP_FUNCTION(ext_power_hold_tap, &ext_power, &ext_power)
 
+#define NAV_HOLD_TAP_FUNCTION(NAME, HOLD_BINDING, BINDING) \
 / { \
   behaviors { \
-    nav_hold_tap: nav_hold_tap {
-      compatible = "zmk,behavior-hold-tap";
-      label = "NAV_HOLD_TAP";
-      #binding-cells = <2>;
-      tapping_term_ms = <220>;
-      quick-tap-ms = <220>;  // repeat on tap-into-hold
-      hold-trigger-key-positions = <0>;  // tap on interrupt
-      flavor = "tap-preferred";
-      bindings = <&kp>, <&kp>;
-    };
-  };
+    NAME: NAME { \
+      compatible = "zmk,behavior-hold-tap"; \
+      label = U_STRINGIFY(NAME); \
+      #binding-cells = <2>; \
+      tapping_term_ms = <220>; \
+      quick-tap-ms = <220>; \
+      hold-trigger-key-positions = <0>; \
+      flavor = "tap-preferred"; \
+      bindings = <HOLD_BINDING>, <BINDING>; \
+    }; \
+  }; \
 };
 
+NAV_HOLD_TAP_FUNCTION(nav_hold_tap, &kp, &kp)
+NAV_HOLD_TAP_FUNCTION(nav_masked_home_hold_tap, U_MASKED_HOME, &kp)
+NAV_HOLD_TAP_FUNCTION(nav_masked_end_hold_tap, U_MASKED_END, &kp)
+
 #define HOLD_TAP(hold, tap) &hold_tap hold tap
-#define NAV_HOLD_TAP(hold, tap) &nav_hold_tap hold tap
 #define OUT_HOLD_TAP(hold, tap) &out_hold_tap hold tap
 #define RGB_HOLD_TAP(hold, tap) &rgb_hold_tap hold tap
 #define EXT_POWER_HOLD_TAP(hold, tap) &ext_power_hold_tap hold tap
+
+#define NAV_HOLD_TAP(hold, tap) &nav_hold_tap hold tap
+#define NAV_MASKED_HOME_TAP(tap) &nav_masked_home_hold_tap 0 tap
+#define NAV_MASKED_END_TAP(tap) &nav_masked_end_hold_tap 0 tap

--- a/miryoku/hold_tap.h
+++ b/miryoku/hold_tap.h
@@ -8,8 +8,11 @@
 #define U_LEFT_RIGHT_BRACKET HOLD_TAP(RIGHT_BRACKET, LEFT_BRACKET)
 
 // Inspired by https://github.com/urob/zmk-config
-#define U_NAV_LEFT  NAV_HOLD_TAP(HOME, LEFT)      // tap: left  | long-tap: beginning of line
-#define U_NAV_RIGHT NAV_HOLD_TAP(END, RIGHT)      // tap: right | long-tap: end of line
+
+// mask CTRL when holding left/right to avoid accidental jumps to beginning/end of document
+#define U_NAV_LEFT  NAV_MASKED_HOME_TAP(LEFT)     // tap: left  | long-tap: beginning of line
+#define U_NAV_RIGHT NAV_MASKED_END_TAP(RIGHT)     // tap: right | long-tap: end of line
+
 #define U_NAV_UP    NAV_HOLD_TAP(LC(HOME), UP)    // tap: up    | long-tap: beginning of document
 #define U_NAV_DOWN  NAV_HOLD_TAP(LC(END), DOWN)   // tap: down  | long-tap: end of document
 #define U_NAV_BSPC  NAV_HOLD_TAP(LC(BSPC), BSPC)  // tap: bspc  | long-tap: delete word backward

--- a/miryoku/mask_mods.dtsi
+++ b/miryoku/mask_mods.dtsi
@@ -1,0 +1,21 @@
+// Copyright 2022 Lukas Kucera
+// https://github.com/kucera-lukas/zmk-config
+
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+
+#define MASK_MODS(NAME, MODS, BINDING) \
+/ { \
+  behaviors { \
+    NAME: NAME { \
+      compatible = "zmk,behavior-mod-morph"; \
+      label = U_STRINGIFY(NAME); \
+      #binding-cells = <0>; \
+      bindings = <BINDING>, <BINDING>; \
+      mods = <MODS>; \
+    }; \
+  }; \
+};
+
+MASK_MODS(masked_home, (MOD_LCTL), &kp HOME)
+MASK_MODS(masked_end, (MOD_LCTL), &kp END)

--- a/miryoku/mask_mods.h
+++ b/miryoku/mask_mods.h
@@ -1,0 +1,5 @@
+// Copyright 2022 Lukas Kucera
+// https://github.com/kucera-lukas/zmk-config
+
+#define U_MASKED_HOME &masked_home
+#define U_MASKED_END &masked_end


### PR DESCRIPTION
- avoid accidental jumps throughout the document by masking ctrl from home/end triggered by long-pressing left/right

- inspired by https://github.com/urob/zmk-config/commit/465b164c8d86718e4b8105a03854bdbd0e0cf7518105a03854bdbd0e0cf751