### PR TITLE
Rename global-quick-tap-ms to require-prior-idle-ms

### DIFF
--- a/miryoku/homerow_mods.dtsi
+++ b/miryoku/homerow_mods.dtsi
@@ -19,7 +19,7 @@
         flavor = "balanced";
         tapping-term-ms = <280>;
         quick-tap-ms = <U_QUICK_TAP_MS>;
-        global-quick-tap-ms = <150>;        // requires PR #1387
+        require-prior-idle-ms = <150>;
         bindings = <&kp>, <&kp>;
         hold-trigger-key-positions = <KEYS_R THUMBS>;
         hold-trigger-on-release;            // requires PR #1423
@@ -32,7 +32,7 @@
         flavor = "balanced";
         tapping-term-ms = <280>;
         quick-tap-ms = <U_QUICK_TAP_MS>;
-        global-quick-tap-ms = <150>;        // requires PR #1387
+        require-prior-idle-ms = <150>;
         bindings = <&kp>, <&kp>;
         hold-trigger-key-positions = <KEYS_L THUMBS>;
         hold-trigger-on-release;            // requires PR #1423


### PR DESCRIPTION
The pull request introducing the global quick tap
functionality has been merged: https://github.com/zmkfirmware/zmk/pull/1387

Hold tap behaviour now supports it via the
`require-prior-idle-ms` option