### PR TITLE
Native support for `hold-trigger-on-release`

### DIFF
--- a/miryoku/homerow_mods.dtsi
+++ b/miryoku/homerow_mods.dtsi
@@ -22,7 +22,7 @@
         require-prior-idle-ms = <150>;
         bindings = <&kp>, <&kp>;
         hold-trigger-key-positions = <KEYS_R THUMBS>;
-        hold-trigger-on-release;            // requires PR #1423
+        hold-trigger-on-release;
       };
 
       hmr: hmr {
@@ -35,7 +35,7 @@
         require-prior-idle-ms = <150>;
         bindings = <&kp>, <&kp>;
         hold-trigger-key-positions = <KEYS_L THUMBS>;
-        hold-trigger-on-release;            // requires PR #1423
+        hold-trigger-on-release;
     };
   };
 };


### PR DESCRIPTION
PR introducing `hold-trigger-on-release` has
been merged into ZMK -- https://github.com/zmkfirmware/zmk/pull/1423