### PR TITLE
Cleanup layer definition

### DIFF
--- a/miryoku/miryoku.dtsi
+++ b/miryoku/miryoku.dtsi
@@ -16,8 +16,8 @@
   keymap {
     compatible = "zmk,keymap";
 #define MIRYOKU_X(LAYER, STRING) \
-    U_##LAYER## { \
-      label = STRING; \
+    LAYER { \
+      display-name = STRING; \
       bindings = < U_MACRO_VA_ARGS(MIRYOKU_LAYERMAPPING_##LAYER, MIRYOKU_LAYER_##LAYER) >; \
     };
 MIRYOKU_LAYER_LIST


### PR DESCRIPTION
- Replace deprecated `label` property with `display-name`
- Remove `U_` prefix from layer name