### PR TITLE
Remove use of ZMK_MACRO

### DIFF
--- a/miryoku/miryoku.h
+++ b/miryoku/miryoku.h
@@ -8,6 +8,17 @@
 
 #define U_MACRO_VA_ARGS(macro, ...) macro(__VA_ARGS__)
 #define U_STRINGIFY(x) #x
+#define U_MACRO(name,...) \
+/ { \
+  macros { \
+    name: name { \
+      label = U_STRINGIFY(ZM_ ## name); \
+      compatible = "zmk,behavior-macro"; \
+      #binding-cells = <0>; \
+      __VA_ARGS__ \
+    }; \
+  }; \
+};
 
 #define U_NP &none // key is not present
 #define U_NA &none // present but not available for use

--- a/miryoku/miryoku_kludge_tapdelay.h
+++ b/miryoku/miryoku_kludge_tapdelay.h
@@ -4,11 +4,7 @@
 #pragma once
 
 #define MIRYOKU_TAPDELAY_TAP(CODE) \
-/ { \
-  macros { \
-    ZMK_MACRO(u_tapdelay_tap_##CODE, bindings = <&macro_press &kp CODE>, <&macro_release &kp CODE>;) \
-  }; \
-};
+U_MACRO(u_tapdelay_tap_##CODE, bindings = <&macro_press &kp CODE>, <&macro_release &kp CODE>;)
 
 #define MIRYOKU_TAPDELAY_MT(CODE) \
 / { \

--- a/miryoku/miryoku_mousekeys.dtsi
+++ b/miryoku/miryoku_mousekeys.dtsi
@@ -1,10 +1,6 @@
 // Copyright 2022 Manna Harbour
 // https://github.com/manna-harbour/miryoku
 
-/ {
-  macros {
-    ZMK_MACRO(u_macro_btn1, wait-ms = <0>; bindings = <&kp KP_SLASH &kp KP_N5>;)
-    ZMK_MACRO(u_macro_btn2, wait-ms = <0>; bindings = <&kp KP_MINUS &kp KP_N5>;)
-    ZMK_MACRO(u_macro_btn3, wait-ms = <0>; bindings = <&kp KP_ASTERISK &kp KP_N5>;)
-  };
-};
+U_MACRO(u_macro_btn1, wait-ms = <0>; bindings = <&kp KP_SLASH &kp KP_N5>;)
+U_MACRO(u_macro_btn2, wait-ms = <0>; bindings = <&kp KP_MINUS &kp KP_N5>;)
+U_MACRO(u_macro_btn3, wait-ms = <0>; bindings = <&kp KP_ASTERISK &kp KP_N5>;)

--- a/miryoku/miryoku_shift_functions.dtsi
+++ b/miryoku/miryoku_shift_functions.dtsi
@@ -15,11 +15,7 @@
 };
 
 #define MIRYOKU_SHIFT_MACRO(NAME, BINDING, SHIFT_BINDING) \
-/ { \
-  macros { \
-    ZMK_MACRO(u_macro_ ## NAME, wait-ms = <0>; bindings = <SHIFT_BINDING>;) \
-  }; \
-}; \
+U_MACRO(u_macro_ ## NAME, wait-ms = <0>; bindings = <SHIFT_BINDING>;) \
 MIRYOKU_SHIFT_FUNCTION(NAME, BINDING, &u_macro_ ## NAME)
 
 MIRYOKU_SHIFT_MACRO(u_bt_sel_0, &bt BT_SEL 0, &bt BT_SEL 0 &bt BT_CLR)


### PR DESCRIPTION
Following the upstream Miryoku ZMK commit:
https://github.com/manna-harbour/miryoku_zmk/commit/12fbc08bc2e8f257b13bd23168fdb558f0ebd1f1