### PR TITLE
Switch to zmkfirmware main

### DIFF
--- a/.github/workflows/build-adv360pro.yml
+++ b/.github/workflows/build-adv360pro.yml
@@ -23,4 +23,4 @@ jobs:
       mapping: '["default"]'
       custom_config: '["#define MIRYOKU_KLUDGE_MOUSEKEYSPR"]'
       kconfig: '["default"]'
-      branches: '["urob/zmk/main"]'
+      branches: '["zmkfirmware/zmk/main"]'

--- a/.github/workflows/outboards/boards/adv360pro
+++ b/.github/workflows/outboards/boards/adv360pro
@@ -1,7 +1,7 @@
 # Copyright 2022 Manna Harbour
 # https://github.com/manna-harbour/miryoku
 
-outboard_repository=urob/zmk
+outboard_repository=zmkfirmware/zmk
 outboard_ref=main
 outboard_from=app/boards/arm/adv360pro
 outboard_to=boards/arm/adv360pro


### PR DESCRIPTION
Start using the outboard definition from
the main branch of ZMK since `urob` has
retired his adv360pro keyboard and no
longer maintains his custom fork.