### PR TITLE
Add tri-state module

### DIFF
--- a/.github/workflows/build-adv360pro.yml
+++ b/.github/workflows/build-adv360pro.yml
@@ -24,3 +24,4 @@ jobs:
       custom_config: '["#define MIRYOKU_KLUDGE_MOUSEKEYSPR"]'
       kconfig: '["default"]'
       branches: '["zmkfirmware/zmk/main"]'
+      modules: '["urob/zmk-tri-state/main"]'


### PR DESCRIPTION
ZMK does not yet natively support the `tri-state`
behaviour. In order to use the "alt/tab" swapper
functionality integrate the zmk-tri-state module
into the build process.