### PR TITLE
Add keymap changes from Kinesis 3.0 branch

### DIFF
--- a/miryoku/combos.dtsi
+++ b/miryoku/combos.dtsi
@@ -17,7 +17,7 @@
     compatible = "zmk,combos";
 
     combo_caps_word_caps {
-      key-positions = <71 76>;
+      key-positions = <65 70>;
       bindings = <U_CAPS_WORD_CAPS>;
       layers = <0>;
     };
@@ -35,7 +35,7 @@
     };
 
     combo_open_clear_clipboard_history {
-      key-positions = <61 62>;
+      key-positions = <55 56>;
       bindings = <U_OPEN_CLEAR_CLIPBOARD_HISTORY>;
       layers = <4 5>;
     };

--- a/miryoku/custom_config.h
+++ b/miryoku/custom_config.h
@@ -36,7 +36,7 @@
 XXX  XXX  XXX  XXX  XXX  XXX  XXX                                               XXX  XXX  XXX  XXX  XXX  XXX  XXX \
 XXX  K00  K01  K02  K03  K04  XXX                                               XXX  K05  K06  K07  K08  K09  XXX \
 XXX  K10  K11  K12  K13  K14  XXX       K32  K32                 K35  K35       XXX  K15  K16  K17  K18  K19  XXX \
-XXX  K20  K21  K22  K23  K24       XXX  XXX  K32  XXX       XXX  K35  XXX  XXX       K25  K26  K27  K28  K29  XXX \
+XXX  K20  K21  K22  K23  K24                 K32                 K35                 K25  K26  K27  K28  K29  XXX \
 XXX  XXX  XXX  XXX  K32            K33  K34  K32                 K35  K37  K36            K35  XXX  XXX  XXX  XXX
 
 #define MIRYOKU_MAPPING MIRYOKU_LAYOUTMAPPING_ADV360PRO

--- a/miryoku/homerow_mods.dtsi
+++ b/miryoku/homerow_mods.dtsi
@@ -7,8 +7,8 @@
 #include <dt-bindings/zmk/keys.h>
 
 #define KEYS_L 15 16 17 18 19 29 30 31 32 33 47 48 49 50 51  // left-hand keys
-#define KEYS_R 22 23 24 25 26 40 41 42 43 44 60 61 62 63 64  // right-hand keys
-#define THUMBS 35 36 37 38 54 57 70 71 72 73 74 75 76 77     // thumb keys
+#define KEYS_R 22 23 24 25 26 40 41 42 43 44 54 55 56 57 58  // right-hand keys
+#define THUMBS 35 36 37 38 52 53 64 65 66 67 68 69 70 71     // thumb keys
 
 / {
     behaviors {


### PR DESCRIPTION
Kinesis has changed the keymap file:
https://github.com/KinesisCorporation/Adv360-Pro-ZMK/blob/V3.0/UPGRADE.md

This was causing wrong alignment of keys